### PR TITLE
Introduce a mechanism to override sota.toml defaults

### DIFF
--- a/ota_api/ota_user.py
+++ b/ota_api/ota_user.py
@@ -5,44 +5,9 @@ import string
 from flask import abort, jsonify, make_response, request
 
 from ota_api.ota_ce import OTACommunityEditionAPI
-from ota_api.settings import GATEWAY_SERVER
+from ota_api.sota_toml import sota_toml_fmt
 
 VALID_DEVICE_CHAR = set(string.ascii_letters + string.digits + '-' + '_' + '/')
-
-SOTA_TOML_FMT = '''
-[tls]
-server = "{gateway_server}"
-ca_source = "file"
-pkey_source = "file"
-cert_source = "file"
-
-[provision]
-server = "{gateway_server}"
-primary_ecu_hardware_id = "{hardware_id}"
-p12_password = ""
-expiry_days = "36000"
-provision_path = ""
-
-[uptane]
-polling = true
-director_server = "{gateway_server}/director"
-repo_server = "{gateway_server}/repo"
-key_source = "file"
-
-[pacman]
-type = "ostree"
-ostree_server = "{gateway_server}/treehub"
-packages_file = "/usr/package.manifest"
-
-[storage]
-type = "sqlite"
-path = "/var/sota/"
-
-[import]
-tls_cacert_path = "/var/sota/root.crt"
-tls_pkey_path = "/var/sota/pkey.pem"
-tls_clientcert_path = "/var/sota/client.pem"
-'''
 
 
 class OTAUserBase(object):
@@ -129,11 +94,6 @@ class OTAUserBase(object):
     def device_create(self, name, uuid, client_pem):
         api = OTACommunityEditionAPI('default')
         api.device_create(name, uuid, client_pem)
-
-    def device_toml(self, hardware_id):
-        """Return the sota.toml needed by aktualizr."""
-        return SOTA_TOML_FMT.format(
-            gateway_server=GATEWAY_SERVER, hardware_id=hardware_id)
 
     def device_cert_create(self, name, uuid, csr):
         """Create a certificate with your CA based on the incoming Certificate

--- a/ota_api/sota_toml.py
+++ b/ota_api/sota_toml.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2019 Foundries.io
+# Author: Marti Bolivar <marti@foundries.io>
+from collections import namedtuple, OrderedDict
+
+from ota_api.settings import GATEWAY_SERVER
+
+SotaConfigCommon = namedtuple('SotaConfigCommon', 'gateway_server')
+
+# TOML values (but not keys) can use {common.gateway_server} or other
+# attributes of the named tuple in format strings access common
+# values.
+SOTA_CONFIG_COMMON = SotaConfigCommon(GATEWAY_SERVER)
+
+# Default SOTA configuration. This is not a complete aktualizr
+# configuration file
+SOTA_CONFIG = OrderedDict([
+    ("tls",
+     OrderedDict([("server", '"{common.gateway_server}"'),
+                  ("ca_source", '"file"'),
+                  ("pkey_source", '"file"'),
+                  ("cert_source", '"file"')])),
+
+    ("provision",
+     OrderedDict([("server", '"{common.gateway_server}"'),
+                  ("p12_password", '""'),
+                  ("expiry_days", '"36000"'),
+                  ("provision_path", '""'),
+                  ("primary_ecu_hardware_id", None)])),
+
+    ("uptane",
+     OrderedDict([("polling", 'true'),
+                  ("director_server", '"{common.gateway_server}/director"'),
+                  ("repo_server", '"{common.gateway_server}/repo"'),
+                  ("key_source", '"file"')])),
+
+    ("pacman",
+     OrderedDict([("type", '"ostree"'),
+                  ("ostree_server", '"{common.gateway_server}/treehub"'),
+                  ("packages_file", '"/usr/package.manifest"')])),
+
+    ("storage",
+     OrderedDict([("type", '"sqlite"'),
+                  ("path", '"/var/sota/"')])),
+
+    ("import",
+     OrderedDict([("tls_cacert_path", '"/var/sota/root.crt"'),
+                  ("tls_pkey_path", '"/var/sota/pkey.pem"'),
+                  ("tls_clientcert_path", '"/var/sota/client.pem"')])),
+])
+
+
+def sota_toml_fmt(common=SOTA_CONFIG_COMMON, overrides=None):
+    d = OrderedDict(SOTA_CONFIG)
+    if overrides:
+        for section in overrides:
+            if section not in d:
+                d[section] = OrderedDict()
+            for k, v in overrides[section].items():
+                d[section][k] = v
+
+    ret = []
+    for section in d:
+        ret.append('[{}]'.format(section))
+        for k, v in d[section].items():
+            if v is None or v == "":
+                # None or an empty string means unset. (For a literal
+                # empty string, use 2 double quote characters, i.e. '""'.)
+                ret.append('# {} is not set'.format(k))
+            else:
+                ret.append('{} = {}'.format(k, v.format(common=common)))
+        ret.append('')
+    return '\n'.join(ret).rstrip() + '\n'


### PR DESCRIPTION
This is related to the needs of:

 https://github.com/foundriesio/lmp-device-register/pull/2

Signed-off-by: Andy Doan <andy@foundries.io>